### PR TITLE
Precise parsing of floats

### DIFF
--- a/examples/function.cpp
+++ b/examples/function.cpp
@@ -30,7 +30,9 @@ auto main() -> int {
         std::cout << result.getError() << std::endl;
     }
 
-    pm.addFunction("rand", [](picomath::number_t input) -> picomath::number_t { return input * rand() / RAND_MAX; });
+    pm.addFunction("rand", [](picomath::number_t input) -> picomath::number_t {
+        return input * static_cast<picomath::number_t>(rand()) / static_cast<picomath::number_t>(RAND_MAX);
+    });
     result = pm.evalExpression("rand(100)");
     if (result.isOk()) {
         std::cout << "Result: " << result.getResult() << std::endl;

--- a/include/picomath.hpp
+++ b/include/picomath.hpp
@@ -2,7 +2,7 @@
  * @file picomath.hpp
  * @author Cesar Guirao Robles (a.k.a. Nitro) <cesar@no2.es>
  * @brief Math expression evaluation. BSD 3-Clause License
- * @version 1.0.0
+ * @version 1.1.0
  * @date 2022-06-01
  *
  * @copyright Copyright (c) 2022, Cesar Guirao Robles (a.k.a. Nitro) <cesar@no2.es>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -21,6 +21,9 @@ TEST_CASE("Simple expressions") {
     REQUIRE(AreSame(ctx.evalExpression("2.003 * 1000").getResult(), 2003.0));
     REQUIRE(AreSame(ctx.evalExpression(".1234").getResult(), 0.1234));
     REQUIRE(AreSame(ctx.evalExpression("123.1234").getResult(), 123.1234));
+    REQUIRE(AreSame(ctx.evalExpression("5e+7").getResult(), 50000000.0));
+    REQUIRE(AreSame(ctx.evalExpression("5e7").getResult(), 50000000.0));
+    REQUIRE(AreSame(ctx.evalExpression("5.0E-7").getResult(), 0.00000049999999873762));
     REQUIRE(AreSame(ctx.evalExpression("-(2+2)").getResult(), -4));
     REQUIRE(ctx.evalExpression("(2+2)").isOk());
     REQUIRE_FALSE(ctx.evalExpression("(2+2)").isError());
@@ -62,6 +65,9 @@ TEST_CASE("Custom units") {
     REQUIRE(AreSame(ctx.evalExpression("1km").getResult(), 1000.0));
     REQUIRE(AreSame(ctx.evalExpression("100km").getResult(), 100000.0));
     REQUIRE(AreSame(ctx.evalExpression("100km - 10").getResult(), 100000.0 - 10.0));
+
+    ctx.addUnit("em") = 10.0;
+    REQUIRE(AreSame(ctx.evalExpression("1em").getResult(), 10.0));
 }
 
 TEST_CASE("Invalid expressions") {


### PR DESCRIPTION
Flag to enable the use of `strtof` to allow precise parsing of floats.
The naive approach is used by default, but it produces numbers with bad precision (enough for some cases)
Also added parsing of exponents in the naive mode.